### PR TITLE
Add brew link to node install

### DIFF
--- a/2-backend-basics/2.0-module-2-overview.md
+++ b/2-backend-basics/2.0-module-2-overview.md
@@ -40,6 +40,7 @@ Install Node version 14 with the following command.
 
 ```
 brew install node@14
+brew link node@14
 ```
 
 #### Windows


### PR DESCRIPTION
Two FTBC6 students are running into linking issues when installing node with `node install node@14` this is solved with `brew link node@14`

![image](https://user-images.githubusercontent.com/17170991/148734532-805ea46f-f8ea-4880-a6a2-337faec24045.png)
