### PR TITLE
Add brew link to node install

### DIFF
--- a/course-logistics/required-hardware-and-software.md
+++ b/course-logistics/required-hardware-and-software.md
@@ -110,6 +110,7 @@ Install Node.js using Homebrew.
 
 ```
 brew install node@14
+brew link node@14
 ```
 
 ## VSCode Formatters


### PR DESCRIPTION
Two FTBC6 students are running into linking issues when installing node with `node install node@14` this is solved with `brew link node@14`

![image](https://user-images.githubusercontent.com/17170991/148734532-805ea46f-f8ea-4880-a6a2-337faec24045.png)