### PR TITLE
Fix row col bug in 1.6 match game

### DIFF
--- a/1-frontend-basics/1.6-match-game.md
+++ b/1-frontend-basics/1.6-match-game.md
@@ -54,15 +54,15 @@ let deck;
 ## Gameplay Logic
 
 ```javascript
-const squareClick = (cardElement, column, row) => {
+const squareClick = (cardElement, row, column) => {
 
     console.log(cardElement);
     
     console.log('FIRST CARD DOM ELEMENT', firstCard);
     
-    console.log('BOARD CLICKED CARD', board[column][row]);
+    console.log('BOARD CLICKED CARD', board[row][column]);
     
-    const clickedCard = board[column][row]; 
+    const clickedCard = board[row][column]; 
 
     // the user already clicked on this square
     if( cardElement.innerText !== '' ){


### PR DESCRIPTION
FTBC6 pointed out that board should be accessed via `board[row][col]` instead of `board[col][row]`