### PR TITLE
Fix WSL file path typo in module 2 setup

### DIFF
--- a/2-backend-basics/2.0-module-2-overview.md
+++ b/2-backend-basics/2.0-module-2-overview.md
@@ -85,7 +85,7 @@ For Windows, Module 2 marks a point that we will change the way files are stored
 Get access to all the files in your WSL Ubuntu instance with this path:
 
 ```
-\\$wsl\Ubuntu
+\\wsl$\Ubuntu-20.04
 ```
 
 #### Opening a Windows file explorer from VSCode Terminal

--- a/2-backend-basics/2.0-module-2-overview.md
+++ b/2-backend-basics/2.0-module-2-overview.md
@@ -82,10 +82,10 @@ For Windows, Module 2 marks a point that we will change the way files are stored
 
 #### Working between WSL and Windows files
 
-Get access to all the files in your WSL Ubuntu instance with this path:
+Apart from the terminal, all the files in your WSL Ubuntu instance can also be accessed from a Windows file explorer window. Type the following path into the address bar of any file explorer window:
 
 ```
-\\wsl$\Ubuntu-20.04
+\\wsl$
 ```
 
 #### Opening a Windows file explorer from VSCode Terminal


### PR DESCRIPTION
- Clarify instructions on how to access WSL files from Windows file explorer
- Fix typo in WSL file path from \\$wsl\Ubuntu to \\wsl$
- Remove \Ubuntu to account for future version folder names