### PR TITLE
Fix typo in 3.ICE.3

### DIFF
--- a/3-backend-applications/3.ice-in-class-exercises/3.ice.3-bigfoot-post.md
+++ b/3-backend-applications/3.ice-in-class-exercises/3.ice.3-bigfoot-post.md
@@ -85,7 +85,7 @@ Add the other Bigfoot sighting attributes to our sighting creation form and save
     http://localhost:3004/year-sightings?sort=desc
     ```
 2. Use an HTML `select` tag in the form to allow the user to select "ascending" or "descending" sort params from the dropdown.
-3.  Add a similar dropdown for other sort options from [3.ICE.1: Bigfoot](3.ice.2-bigfoot-ejs.md#sort-by). These might produce the following URLs.
+3.  Add a similar dropdown for other sort options from [3.ICE.2: Bigfoot EJS](3.ice.2-bigfoot-ejs.md#sort-by). These might produce the following URLs.
 
     ```markup
     http://localhost:3004/?sortBy=year


### PR DESCRIPTION
under
**Add Sort Forms for Sightings List**
"_Point 3: Add a similar dropdown for other sort options from [3.ICE.**1**: Bigfoot EJS] ..._  "

- 3.ICE.1 has nothing on ?sort - only 3.ICE.2 page section on 'Sort By' has the relevant that the learner needs to finish before being able to handle 3.ICE.3's  'Add Sort Forms for Sightings List'